### PR TITLE
Updated brand details of Parr Lumber

### DIFF
--- a/data/brands/shop/trade.json
+++ b/data/brands/shop/trade.json
@@ -204,6 +204,22 @@
         "trade": "building_supplies"
       }
     },
+     {
+        "displayName": "Parr Lumber",
+        "id": "",
+        "locationSet": {"include": ["us"]},
+        "matchTags": [
+            "shop/door",
+          ],
+        "tags": {
+          "brand": "Parr Lumber",
+          "brand:wikidata": "Q7139721",
+          "brand:wikipedia": "en:Parr Lumber",
+          "name": "Parr Lumber",
+          "shop": "trade",
+          "trade": "building_supplies"
+        }
+    },
     {
       "displayName": "Raab Karcher",
       "id": "raabkarcher-c82403",


### PR DESCRIPTION
Updated brand Parr Lumber as a fix to the issue #5327 (https://github.com/osmlab/name-suggestion-index/issues/5327)